### PR TITLE
Preserve logger name

### DIFF
--- a/src/Akka.Logger.NLog/NLogLogger.cs
+++ b/src/Akka.Logger.NLog/NLogLogger.cs
@@ -54,7 +54,7 @@ namespace Akka.Logger.NLog
 
         private static void LogEvent(NLogger logger, NLogLevel level, string logSource, Exception exception, string message, params object[] parameters)
         {
-            var logEvent = new LogEventInfo(level, "", null, message, parameters, exception);
+            var logEvent = new LogEventInfo(level, logger.Name, null, message, parameters, exception);
             logEvent.Properties["logSource"] = logSource;
             logger.Log(logEvent);
         }


### PR DESCRIPTION
NLog requires you set the `logger` name on the `LogEventInfo`  (else you just get a blank logger name)