### PR TITLE
NLogLogger - Optimize logging of LogMessage when Parameters() is object-array

### DIFF
--- a/src/Akka.Logger.NLog.Tests/Akka.Logger.NLog.Tests.csproj
+++ b/src/Akka.Logger.NLog.Tests/Akka.Logger.NLog.Tests.csproj
@@ -6,8 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Akka.TestKit.Xunit2" />
   </ItemGroup>
 

--- a/src/Akka.Logger.NLog/NLogLogger.cs
+++ b/src/Akka.Logger.NLog/NLogLogger.cs
@@ -57,7 +57,7 @@ namespace Akka.Logger.NLog
                 return;
             
             var logEventInfo = logEvent.Message is LogMessage logMessage ?
-                new LogEventInfo(level, logger.Name, null, logMessage.Format, logMessage.Parameters().ToArray(), exception) :
+                new LogEventInfo(level, logger.Name, null, logMessage.Format, GetLogMessageParameterArray(logMessage), exception) :
                 new LogEventInfo(level, logger.Name, null, "{0}", new object[] { logEvent.Message.ToString() }, exception);
             if (logEventInfo.TimeStamp.Kind == logEvent.Timestamp.Kind)
                 logEventInfo.TimeStamp = logEvent.Timestamp;            // Timestamp of original LogEvent (instead of async Logger thread timestamp)
@@ -65,6 +65,12 @@ namespace Akka.Logger.NLog
             logEventInfo.Properties["actorPath"] = Context?.Sender?.Path?.ToString() ?? string.Empty;   // Same as Serilog
             logEventInfo.Properties["threadId"] = logEvent.Thread.ManagedThreadId;  // ThreadId of the original LogEvent (instead of async Logger threadid)
             logger.Log(logEventInfo);
+        }
+
+        private static object[] GetLogMessageParameterArray(LogMessage logMessage)
+        {
+            var parameters = logMessage.Parameters();
+            return parameters is object[] parameterArray ? parameterArray : parameters?.ToArray();
         }
     }
 }

--- a/src/Akka.Logger.NLog/NLogMessageFormatter.cs
+++ b/src/Akka.Logger.NLog/NLogMessageFormatter.cs
@@ -6,23 +6,21 @@ using NLogLevel = global::NLog.LogLevel;
 
 namespace Akka.Logger.NLog
 {
-    /// <inheritdoc />
     /// <summary>
     /// This class contains methods used to convert MessageTemplated messages
     /// into normal text messages.
     /// </summary>
+    /// <remarks>
+    /// You need to enable the Akka.Logger.NLog.NLogMessageFormatter across your entire ActorSystem - this will replace Akka.NET's default ILogMessageFormatter with NLog's.
+    /// 
+    /// You can accomplish this by setting the akka.logger-formatter setting like below:
+    /// <code>
+    /// akka.logger-formatter="Akka.Logger.NLog.NLogMessageFormatter, Akka.Logger.NLog"
+    /// </code>
+    /// </remarks>
     public class NLogMessageFormatter : ILogMessageFormatter
     {
-        /// <summary>
-        /// Converts the specified template string to a text string using the specified
-        /// token array to match replacements.
-        /// </summary>
-        /// <param name="format">The template string used in the conversion.</param>
-        /// <param name="args">The array that contains values to replace in the template.</param>
-        /// <returns>
-        /// A text string where the template placeholders have been replaced with
-        /// their corresponding values.
-        /// </returns>
+        /// <inheritdoc />
         public string Format(string format, params object[] args)
         {
             if (args?.Length > 0)
@@ -32,6 +30,7 @@ namespace Akka.Logger.NLog
             return format;
         }
 
+        /// <inheritdoc />
         public string Format(string format, IEnumerable<object> args)
             => Format(format, args.ToArray());
     }


### PR DESCRIPTION
## Changes

- Minor optimization when LogMessage-Parameters() returns object-array

## Checklist

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.