### PR TITLE
NLogLogger - Skip enumerating Properties when empty collection

### DIFF
--- a/src/Akka.Logger.NLog/NLogLogger.cs
+++ b/src/Akka.Logger.NLog/NLogLogger.cs
@@ -64,7 +64,7 @@ namespace Akka.Logger.NLog
 
             // Add structured logging properties from semantic logging
             // This enables NLog layouts and targets to access structured properties by name
-            if (logEvent.TryGetProperties(out var properties))
+            if (logEvent.TryGetProperties(out var properties) && properties?.Count > 0)
             {
                 foreach (var prop in properties)
                 {


### PR DESCRIPTION
NLog has its own parsing and rendering, but now also gets the additional overhead from Akka's parsing / allocations. I think it should either be Akka or NLog handling the structured logging. I can see Serilog is allowed to handle the structured logging alone (parses and renders). Any reason why NLog is forced to call `LogEventExtensions.TryGetProperties()` ?

I find it strange that when calling Akka's `LogMessage.ToString()` and using semantic logging, then Akka-Formatter explodes in your face (Because `string.Format` only handles positional parameters).

Also strange that Akka LogMessage only supports message-template-properties. I find message-template properties very organic and error-prone (case-sensitive, spelling, etc.) compared to explicit "building" the LogEvent.