### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2023 Akka.NET Contrib Team</Copyright>
     <Authors>Akka.NET Contrib Team</Authors>
-    <PackageReleaseNotes>* [Upgrade Akka.NET to v1.5.13](https://github.com/akkadotnet/akka.net/releases/tag/1.5.13)
-* [Bump NLog to 5.2.4](https://github.com/akkadotnet/Akka.Logger.NLog/pull/171)</PackageReleaseNotes>
-    <VersionPrefix>1.5.13</VersionPrefix>
+    <PackageReleaseNotes>**Dependency Updates**
+* [Upgraded to Akka.NET v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
+    <VersionPrefix>1.5.59</VersionPrefix>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.57-Beta2</AkkaVersion>
+    <AkkaVersion>1.5.59</AkkaVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="TestLab" value="https://nuget.testlab.petabridge.net/v3/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="TestLab" value="https://nuget.testlab.petabridge.net/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.59 January 26th 2026 ####
+
+**Dependency Updates**
+* [Upgraded to Akka.NET v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+
 #### 1.5.57-beta2 December 4th 2025 ####
 
 **New Features**


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)