### PR TITLE
Update version to 1.5.60 and add release notes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2023 Akka.NET Contrib Team</Copyright>
     <Authors>Akka.NET Contrib Team</Authors>
-    <PackageReleaseNotes>**Dependency Updates**
-* [Upgraded to Akka.NET v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
-    <VersionPrefix>1.5.59</VersionPrefix>
+    <PackageReleaseNotes>**New Features**
+* [Verified `WithContext()` logging context enrichment support](https://github.com/akkadotnet/akka.logger.nlog/pull/249)
+**Dependency Updates**
+* [Upgraded to Akka.NET v1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)</PackageReleaseNotes>
+    <VersionPrefix>1.5.60</VersionPrefix>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#### 1.5.60 February 10th 2026 ####
+
+**New Features**
+* [Verified `WithContext()` logging context enrichment support](https://github.com/akkadotnet/akka.logger.nlog/pull/249) - Akka.NET 1.5.60's `WithContext()` API flows context properties through to NLog `LogEventInfo.Properties` automatically. No code changes were needed -- NLog already called `TryGetProperties()`.
+
+**Dependency Updates**
+* [Upgraded to Akka.NET v1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)
+
 #### 1.5.59 January 26th 2026 ####
 
 **Dependency Updates**


### PR DESCRIPTION
## Summary

- Update VersionPrefix to 1.5.60
- Add release notes for 1.5.60 documenting WithContext() support verification
- Update PackageReleaseNotes

## Changes

- Akka.NET dependency bumped to 1.5.60
- WithContext() integration tests confirmed NLog already supports context enrichment via TryGetProperties() with no code changes needed