### PR TITLE
Add Akka.Hosting integration demo + integration tests

### DIFF
--- a/Akka.Logger.NLog.sln
+++ b/Akka.Logger.NLog.sln
@@ -34,29 +34,84 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build-system", "build-syste
 		build-system\nightly-builds.yaml = build-system\nightly-builds.yaml
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{5F800AEC-81E7-8274-1389-B9340FE786D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Logger.NLog.HostingDemo", "src\Examples\Akka.Logger.NLog.HostingDemo\Akka.Logger.NLog.HostingDemo.csproj", "{578129CC-2113-4433-80C9-D0DFF18943AF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Logger.NLog.Hosting.Tests", "src\Akka.Logger.NLog.Hosting.Tests\Akka.Logger.NLog.Hosting.Tests.csproj", "{0C65E620-57FB-4076-AB5E-2E294D244881}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Debug|x64.Build.0 = Debug|Any CPU
+		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Debug|x86.Build.0 = Debug|Any CPU
 		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Release|x64.ActiveCfg = Release|Any CPU
+		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Release|x64.Build.0 = Release|Any CPU
+		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Release|x86.ActiveCfg = Release|Any CPU
+		{52BC97B2-C762-4029-878E-47E2EA9866D2}.Release|x86.Build.0 = Release|Any CPU
 		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Debug|x64.Build.0 = Debug|Any CPU
+		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Debug|x86.Build.0 = Debug|Any CPU
 		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Release|x64.ActiveCfg = Release|Any CPU
+		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Release|x64.Build.0 = Release|Any CPU
+		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Release|x86.ActiveCfg = Release|Any CPU
+		{32923A88-E86B-4E73-9621-E7599DF36E5F}.Release|x86.Build.0 = Release|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Debug|x86.Build.0 = Debug|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Release|x64.Build.0 = Release|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{578129CC-2113-4433-80C9-D0DFF18943AF}.Release|x86.Build.0 = Release|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Debug|x64.Build.0 = Debug|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Debug|x86.Build.0 = Debug|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Release|x64.ActiveCfg = Release|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Release|x64.Build.0 = Release|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Release|x86.ActiveCfg = Release|Any CPU
+		{0C65E620-57FB-4076-AB5E-2E294D244881}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {E6D29FE3-301D-4898-BD68-BFA6785695BB}
-	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{519BA4A5-2081-4D8B-AC96-70EC04591BB6} = {BB691E2E-B766-4EAA-8592-3129F83ACA9F}
 		{20ECC18B-22D4-40AA-A491-22121ACD985A} = {BB691E2E-B766-4EAA-8592-3129F83ACA9F}
+		{5F800AEC-81E7-8274-1389-B9340FE786D1} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{578129CC-2113-4433-80C9-D0DFF18943AF} = {5F800AEC-81E7-8274-1389-B9340FE786D1}
+		{0C65E620-57FB-4076-AB5E-2E294D244881} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E6D29FE3-301D-4898-BD68-BFA6785695BB}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,10 @@
   <!-- App dependencies -->
   <ItemGroup>
     <PackageVersion Include="Akka" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Hosting" Version="1.5.60" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="NLog" Version="6.0.6" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.15" />
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>

--- a/src/Akka.Logger.NLog.Hosting.Tests/Akka.Logger.NLog.Hosting.Tests.csproj
+++ b/src/Akka.Logger.NLog.Hosting.Tests/Akka.Logger.NLog.Hosting.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka" />
+    <PackageReference Include="Akka.Hosting" />
+    <PackageReference Include="Akka.TestKit.Xunit2" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NLog" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Akka.Logger.NLog\Akka.Logger.NLog.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/Akka.Logger.NLog.Hosting.Tests/AkkaHostingIntegrationSpecs.cs
+++ b/src/Akka.Logger.NLog.Hosting.Tests/AkkaHostingIntegrationSpecs.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using Xunit;
+
+namespace Akka.Logger.NLog.Hosting.Tests
+{
+    /// <summary>
+    /// Integration tests that verify Akka log events flow end-to-end through the
+    /// Akka.Hosting wiring (AddLogger&lt;NLogLogger&gt;) into a real NLog MemoryTarget.
+    /// </summary>
+    public class AkkaHostingIntegrationSpecs : IAsyncLifetime
+    {
+        private IHost? _host;
+        private MemoryTarget? _memoryTarget;
+
+        public async Task InitializeAsync()
+        {
+            // Wire NLog to capture everything in memory for the duration of each test.
+            _memoryTarget = new MemoryTarget("memory") { Layout = "${message}" };
+            var loggingConfig = new LoggingConfiguration();
+            loggingConfig.AddTarget(_memoryTarget);
+            loggingConfig.AddRule(global::NLog.LogLevel.Debug, global::NLog.LogLevel.Fatal, _memoryTarget, "*");
+            LogManager.Configuration = loggingConfig;
+
+            _host = Host.CreateDefaultBuilder()
+                .ConfigureServices((_, services) =>
+                {
+                    services.AddAkka("NLogHostingTestSystem", cb =>
+                    {
+                        cb.ConfigureLoggers(lc =>
+                        {
+                            lc.ClearLoggers();
+                            lc.AddLogger<NLogLogger>();
+                            lc.LogLevel = Akka.Event.LogLevel.DebugLevel;
+                        });
+                    });
+                })
+                .Build();
+
+            await _host.StartAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_host is not null)
+            {
+                await _host.StopAsync();
+                _host.Dispose();
+            }
+        }
+
+        [Fact(DisplayName = "Log events emitted via Akka ILoggingAdapter should appear in NLog MemoryTarget")]
+        public async Task AkkaLogEventsShouldReachNLogMemoryTarget()
+        {
+            var actorSystem = _host!.Services.GetRequiredService<ActorSystem>();
+            var logger = Logging.GetLogger(actorSystem.EventStream, "HostingIntegrationTest");
+
+            const string expectedFragment = "Hello from Akka.Hosting NLog integration";
+            logger.Info("Hello from Akka.Hosting NLog integration");
+
+            // Give the async Akka log dispatcher time to process the event.
+            await Task.Delay(TimeSpan.FromMilliseconds(600));
+
+            var logs = _memoryTarget!.Logs.ToArray();
+            logs.Should().NotBeEmpty("the MemoryTarget should have received at least one log entry");
+            logs.Should().Contain(
+                l => l.Contains(expectedFragment),
+                $"expected a log entry containing '{expectedFragment}' but got: {string.Join("; ", logs)}");
+        }
+
+        [Fact(DisplayName = "Structured / parameterised Akka log messages should reach NLog MemoryTarget")]
+        public async Task StructuredAkkaLogMessagesShouldReachNLogMemoryTarget()
+        {
+            // Reconfigure MemoryTarget layout to expose structured properties.
+            _memoryTarget!.Layout = "${message}|UserId=${event-properties:UserId}";
+
+            var actorSystem = _host!.Services.GetRequiredService<ActorSystem>();
+            var logger = Logging.GetLogger(actorSystem.EventStream, "StructuredTest");
+
+            logger.Info("User {UserId} signed in", 42);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(600));
+
+            var logs = _memoryTarget.Logs.ToArray();
+            logs.Should().NotBeEmpty("MemoryTarget should have entries after structured log");
+            logs.Should().Contain(
+                l => l.Contains("UserId=42"),
+                $"expected structured property 'UserId=42' but got: {string.Join("; ", logs)}");
+        }
+
+        [Fact(DisplayName = "Warning-level Akka log events should reach NLog MemoryTarget")]
+        public async Task WarningLevelEventsShouldReachNLogMemoryTarget()
+        {
+            _memoryTarget!.Layout = "${level:uppercase=true}|${message}";
+
+            var actorSystem = _host!.Services.GetRequiredService<ActorSystem>();
+            var logger = Logging.GetLogger(actorSystem.EventStream, "WarnTest");
+
+            logger.Warning("Something looks off: {Reason}", "disk almost full");
+
+            await Task.Delay(TimeSpan.FromMilliseconds(600));
+
+            var logs = _memoryTarget.Logs.ToArray();
+            logs.Should().NotBeEmpty();
+            logs.Should().Contain(
+                l => l.StartsWith("WARN") && l.Contains("disk almost full"),
+                $"expected a WARN entry but got: {string.Join("; ", logs)}");
+        }
+
+        [Fact(DisplayName = "Actor-level ILoggingAdapter should route messages through NLogLogger via Akka.Hosting")]
+        public async Task ActorLoggingAdapterShouldRouteMessagesViaNLog()
+        {
+            _memoryTarget!.Layout = "${message}";
+
+            var actorSystem = _host!.Services.GetRequiredService<ActorSystem>();
+
+            // Spawn a transient probe actor that logs one message then stops.
+            const string marker = "AKKA_HOSTING_ACTOR_LOG_MARKER";
+            var probe = actorSystem.ActorOf(Props.Create(() => new LoggingProbeActor(marker)), "probe");
+            probe.Tell("go");
+
+            await Task.Delay(TimeSpan.FromMilliseconds(800));
+
+            var logs = _memoryTarget.Logs.ToArray();
+            logs.Should().Contain(
+                l => l.Contains(marker),
+                $"expected '{marker}' from actor-level logger but got: {string.Join("; ", logs)}");
+        }
+    }
+
+    /// <summary>
+    /// A minimal actor that logs a marker string as soon as it receives any message,
+    /// then stops itself.
+    /// </summary>
+    internal sealed class LoggingProbeActor : ReceiveActor
+    {
+        public LoggingProbeActor(string marker)
+        {
+            var log = Logging.GetLogger(Context);
+            Receive<string>(_ =>
+            {
+                log.Info(marker);
+                Context.Stop(Self);
+            });
+        }
+    }
+}

--- a/src/Akka.Logger.NLog.Hosting.Tests/xunit.runner.json
+++ b/src/Akka.Logger.NLog.Hosting.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "all"
+}

--- a/src/Examples/Akka.Logger.NLog.HostingDemo/Akka.Logger.NLog.HostingDemo.csproj
+++ b/src/Examples/Akka.Logger.NLog.HostingDemo/Akka.Logger.NLog.HostingDemo.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka" />
+    <PackageReference Include="Akka.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="NLog" />
+    <PackageReference Include="NLog.Extensions.Logging" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Akka.Logger.NLog\Akka.Logger.NLog.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Examples/Akka.Logger.NLog.HostingDemo/Program.cs
+++ b/src/Examples/Akka.Logger.NLog.HostingDemo/Program.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting;
+using Akka.Logger.NLog;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NLog;
+using NLog.Config;
+using NLog.Layouts;
+using NLog.Targets;
+
+// -----------------------------------------------------------------------
+// Configure NLog to write structured output to the console.
+// -----------------------------------------------------------------------
+var loggingConfig = new LoggingConfiguration();
+var consoleTarget = new ConsoleTarget("console")
+{
+    Layout = Layout.FromString(
+        "${date:format=HH\\:mm\\:ss.fff} [${level:uppercase=true}] ${logger} - ${message}" +
+        "${onexception:${newline}${exception:format=tostring}}" +
+        " | source=${event-properties:logSource}" +
+        " | thread=${event-properties:threadId}")
+};
+loggingConfig.AddTarget(consoleTarget);
+loggingConfig.AddRule(NLog.LogLevel.Debug, NLog.LogLevel.Fatal, consoleTarget, "*");
+LogManager.Configuration = loggingConfig;
+
+// -----------------------------------------------------------------------
+// Build the generic host, wire Akka.Hosting + NLogLogger.
+// -----------------------------------------------------------------------
+var host = Host.CreateDefaultBuilder(args)
+    .UseConsoleLifetime()
+    .ConfigureServices((_, services) =>
+    {
+        services.AddAkka("NLogDemoSystem", cb =>
+        {
+            cb.ConfigureLoggers(lc =>
+            {
+                lc.ClearLoggers();               // drop Akka's default console logger
+                lc.AddLogger<NLogLogger>();       // route Akka log events into NLog
+                lc.LogLevel = Akka.Event.LogLevel.DebugLevel;
+            });
+
+            // Register a simple greeter actor so we can generate log messages.
+            cb.WithActors((system, registry) =>
+            {
+                var greeter = system.ActorOf(Props.Create<GreeterActor>(), "greeter");
+                registry.Register<GreeterActor>(greeter);
+            });
+        });
+
+        // Add a hosted service that exercises the actor and then shuts down.
+        services.AddHostedService<DemoRunner>();
+    })
+    .Build();
+
+await host.RunAsync();
+
+// -----------------------------------------------------------------------
+// Actor that logs structured messages when it receives greet requests.
+// -----------------------------------------------------------------------
+public sealed class GreeterActor : ReceiveActor
+{
+    private readonly ILoggingAdapter _log = Logging.GetLogger(Context);
+    private int _count;
+
+    public GreeterActor()
+    {
+        Receive<string>(name =>
+        {
+            _count++;
+            // Structured / parameterised log – verifies template forwarding.
+            _log.Info("Greeting #{Count} sent to {Name} from actor {ActorPath}",
+                _count, name, Self.Path);
+        });
+
+        Receive<int>(n =>
+        {
+            _log.Debug("Received numeric message: {Value}", n);
+        });
+    }
+}
+
+// -----------------------------------------------------------------------
+// IHostedService that drives the demo, then requests host shutdown.
+// -----------------------------------------------------------------------
+public sealed class DemoRunner : IHostedService
+{
+    private readonly ActorRegistry _registry;
+    private readonly IHostApplicationLifetime _lifetime;
+
+    public DemoRunner(ActorRegistry registry, IHostApplicationLifetime lifetime)
+    {
+        _registry = registry;
+        _lifetime = lifetime;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var greeter = _registry.Get<GreeterActor>();
+
+        greeter.Tell("Alice");
+        greeter.Tell("Bob");
+        greeter.Tell(42);
+        greeter.Tell("Charlie");
+
+        // Give Akka's async log dispatcher a moment to flush all messages.
+        await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
+
+        _lifetime.StopApplication();
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary
Adds a runnable Akka.Hosting integration demo and automated integration tests for the NLog logger adapter. There was previously no Akka.Hosting example or validation in this repo.

## What's added
- `src/Examples/Akka.Logger.NLog.HostingDemo` — console app wiring NLog through `Akka.Hosting` (`ConfigureLoggers` → `ClearLoggers()` + `AddLogger<NLogLogger>()`)
- `src/Akka.Logger.NLog.Hosting.Tests` — 4 integration tests that boot a real `IHost`/`ActorSystem`, emit Akka log events, and assert an NLog `MemoryTarget` captured them
- `Akka.Hosting` 1.5.60 added to `Directory.Packages.props` (matches the repo's Akka 1.5.60)

## Validation
`dotnet test` → 20/20 passing (4 new + 16 existing). The example app runs and routes structured Akka log events through NLog.

README documentation for the Akka.Hosting setup will follow in a separate PR.