### PR TITLE
Upgrade to Akka.NET 1.5.69

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2023 Akka.NET Contrib Team</Copyright>
     <Authors>Akka.NET Contrib Team</Authors>
-    <PackageReleaseNotes>**New Features**
-* [Verified `WithContext()` logging context enrichment support](https://github.com/akkadotnet/akka.logger.nlog/pull/249)
-**Dependency Updates**
-* [Upgraded to Akka.NET v1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)</PackageReleaseNotes>
-    <VersionPrefix>1.5.60</VersionPrefix>
+    <PackageReleaseNotes>**Dependency Updates**
+* [Upgraded to Akka.NET v1.5.69](https://github.com/akkadotnet/akka.net/releases/tag/1.5.69)</PackageReleaseNotes>
+    <VersionPrefix>1.5.69</VersionPrefix>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,12 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.60</AkkaVersion>
+    <AkkaVersion>1.5.69</AkkaVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
     <PackageVersion Include="Akka" Version="$(AkkaVersion)" />
-    <PackageVersion Include="Akka.Hosting" Version="1.5.60" />
+    <PackageVersion Include="Akka.Hosting" Version="1.5.69" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="NLog" Version="6.0.6" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.15" />


### PR DESCRIPTION
Bumps Akka, Akka.Hosting, and Akka.TestKit to 1.5.69 (latest). Build + all tests green.

## Changes
- `Directory.Packages.props`: `AkkaVersion` 1.5.60 → 1.5.69, `Akka.Hosting` 1.5.60 → 1.5.69
- `Directory.Build.props`: `VersionPrefix` 1.5.60 → 1.5.69, updated release notes

## Test Results
- Passed: 24 tests (20 core + 4 hosting), Failed: 0, Skipped: 0